### PR TITLE
프로필 사진 수정 API 구현

### DIFF
--- a/be/src/main/java/kr/codesquad/core/error/statuscode/FileErrorCode.java
+++ b/be/src/main/java/kr/codesquad/core/error/statuscode/FileErrorCode.java
@@ -7,7 +7,8 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public enum FileErrorCode implements StatusCode {
 	FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
-	MULTIFILE_CONVERT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "멀티 파일 변환에 실패했습니다.");
+	MULTIFILE_CONVERT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "멀티 파일 변환에 실패했습니다."),
+	DIRECTROTY_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "파일에 해당하는 디렉토리를 찾을 수 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/be/src/main/java/kr/codesquad/image/service/AmazonS3Service.java
+++ b/be/src/main/java/kr/codesquad/image/service/AmazonS3Service.java
@@ -34,11 +34,11 @@ public class AmazonS3Service {
 		S3ImageDirectory.PROFILE_IMAGE.name() + "/" + "%EC%BD%94%EB%81%BC%EB%A6%AC.png"; // "코끼리.png"
 
 	@Transactional
-	public String upload(MultipartFile multipartFile, String dirName) {
+	public String upload(MultipartFile multipartFile, S3ImageDirectory s3ImageDirectory) {
 		File file = convertMultiPartFileToFile(multipartFile).orElseThrow(
 			() -> new CustomException(FileErrorCode.FILE_UPLOAD_FAIL));
 		// random file name
-		String key = dirName + "/" + UUID.randomUUID() + file.getName();
+		String key = s3ImageDirectory.getDirName() + "/" + UUID.randomUUID() + file.getName();
 		// put S3
 		amazonS3.putObject(new PutObjectRequest(bucketName, key, file).withCannedAcl(
 			CannedAccessControlList.PublicRead));

--- a/be/src/main/java/kr/codesquad/image/service/AmazonS3Service.java
+++ b/be/src/main/java/kr/codesquad/image/service/AmazonS3Service.java
@@ -14,10 +14,12 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 
 import kr.codesquad.core.error.CustomException;
 import kr.codesquad.core.error.statuscode.FileErrorCode;
+import kr.codesquad.util.S3ImageDirectory;
 
 @Service
 public class AmazonS3Service {
@@ -27,6 +29,9 @@ public class AmazonS3Service {
 
 	@Autowired
 	private AmazonS3 amazonS3;
+
+	private static final String DEFAULT_PROFILE_IMAGE =
+		S3ImageDirectory.PROFILE_IMAGE.name() + "/" + "%EC%BD%94%EB%81%BC%EB%A6%AC.png"; // "코끼리.png"
 
 	@Transactional
 	public String upload(MultipartFile multipartFile, String dirName) {
@@ -53,5 +58,15 @@ public class AmazonS3Service {
 			throw new CustomException(FileErrorCode.MULTIFILE_CONVERT_FAIL);
 		}
 		return Optional.of(convertedFile);
+	}
+
+	public void deleteImage(String fileUrl) {
+		String dirPath = S3ImageDirectory.findDirectory(fileUrl) + "/";
+		String fileName = fileUrl.substring(fileUrl.indexOf(dirPath) + dirPath.length());
+		String key = dirPath + fileName;
+
+		if (!DEFAULT_PROFILE_IMAGE.equals(key)) { // 기본 프로필 이미지가 아닌 경우에만 S3에서 삭제
+			amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));
+		}
 	}
 }

--- a/be/src/main/java/kr/codesquad/item/service/ItemService.java
+++ b/be/src/main/java/kr/codesquad/item/service/ItemService.java
@@ -3,6 +3,7 @@ package kr.codesquad.item.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -34,6 +35,7 @@ import kr.codesquad.location.repository.LocationRepository;
 import kr.codesquad.user.entity.User;
 import kr.codesquad.user.repository.UserRepository;
 import kr.codesquad.util.ItemStatus;
+import kr.codesquad.util.S3ImageDirectory;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -69,7 +71,7 @@ public class ItemService {
 			.status(ItemStatus.판매중)
 			.build());
 		if (imageFiles.size() != 0) {
-			String url = amazonS3Service.upload(imageFiles.get(0), "itemImage");
+			String url = amazonS3Service.upload(imageFiles.get(0), S3ImageDirectory.ITEM_IMAGE);
 			imageRepository.save(Image.builder()
 				.url(url)
 				.itemId(item.getId())
@@ -77,7 +79,7 @@ public class ItemService {
 			thumbnailUrl = url;
 			for (int i = 1; i < imageFiles.size(); i++) {
 				imageRepository.save(Image.builder()
-					.url(amazonS3Service.upload(imageFiles.get(i), "itemImage"))
+					.url(amazonS3Service.upload(imageFiles.get(i), S3ImageDirectory.ITEM_IMAGE))
 					.itemId(item.getId())
 					.build());
 			}

--- a/be/src/main/java/kr/codesquad/user/controller/UserController.java
+++ b/be/src/main/java/kr/codesquad/user/controller/UserController.java
@@ -7,6 +7,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,6 +21,7 @@ import kr.codesquad.favorite.service.FavoriteService;
 import kr.codesquad.item.dto.slice.UserItemListSlice;
 import kr.codesquad.item.service.ItemService;
 import kr.codesquad.user.dto.request.UserSignUpRequest;
+import kr.codesquad.user.dto.response.UpdateProfileImageResponse;
 import kr.codesquad.user.service.UserService;
 import kr.codesquad.util.Constants;
 import lombok.RequiredArgsConstructor;
@@ -66,5 +68,12 @@ public class UserController {
 		String loginId = (String)request.getAttribute(Constants.LOGIN_ID);
 		return ResponseEntity.ok()
 			.body(favoriteService.getFavoriteCategories(loginId));
+	}
+
+	@PatchMapping("/profile-image")
+	public ResponseEntity<UpdateProfileImageResponse> updateProfileImage(@RequestParam MultipartFile profileImageFile,
+		HttpServletRequest request) {
+		String userLoginId = (String)request.getAttribute(Constants.LOGIN_ID);
+		return ResponseEntity.ok().body(userService.updateProfileImage(profileImageFile, userLoginId));
 	}
 }

--- a/be/src/main/java/kr/codesquad/user/dto/response/UpdateProfileImageResponse.java
+++ b/be/src/main/java/kr/codesquad/user/dto/response/UpdateProfileImageResponse.java
@@ -1,0 +1,10 @@
+package kr.codesquad.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateProfileImageResponse {
+	private String profileImageUrl;
+}

--- a/be/src/main/java/kr/codesquad/user/entity/User.java
+++ b/be/src/main/java/kr/codesquad/user/entity/User.java
@@ -36,4 +36,8 @@ public class User {
 		this.password = password;
 		this.nickname = nickname;
 	}
+
+	public void updateProfileImage(String profileImageUrl) {
+		this.profileImageUrl = profileImageUrl;
+	}
 }

--- a/be/src/main/java/kr/codesquad/user/service/UserService.java
+++ b/be/src/main/java/kr/codesquad/user/service/UserService.java
@@ -64,9 +64,11 @@ public class UserService implements UserDetailsService {
 
 	@Transactional
 	public UpdateProfileImageResponse updateProfileImage(MultipartFile profileImageFile, String userLoginId) {
-		// TODO: 기존 이미지 파일 삭제 로직 추가 (S3 용량 관리)
+		User user = userRepository.findByLoginId(userLoginId);
+		amazonS3Service.deleteImage(user.getProfileImageUrl()); // 기존 프로필 이미지 삭제
+
 		String newProfileImageUrl = amazonS3Service.upload(profileImageFile, "profileImage");
-		userRepository.findByLoginId(userLoginId).updateProfileImage(newProfileImageUrl);
+		user.updateProfileImage(newProfileImageUrl);
 
 		return new UpdateProfileImageResponse(newProfileImageUrl);
 	}

--- a/be/src/main/java/kr/codesquad/user/service/UserService.java
+++ b/be/src/main/java/kr/codesquad/user/service/UserService.java
@@ -1,7 +1,6 @@
 package kr.codesquad.user.service;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -16,6 +15,7 @@ import kr.codesquad.location.entity.Location;
 import kr.codesquad.location.repository.LocationRepository;
 import kr.codesquad.user.dto.UserMapper;
 import kr.codesquad.user.dto.request.UserSignUpRequest;
+import kr.codesquad.user.dto.response.UpdateProfileImageResponse;
 import kr.codesquad.user.entity.User;
 import kr.codesquad.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -60,5 +60,14 @@ public class UserService implements UserDetailsService {
 		User user = userRepository.findByLoginId(username);
 		return new org.springframework.security.core.userdetails.User(username, user.getPassword(),
 			new ArrayList<>());
+	}
+
+	@Transactional
+	public UpdateProfileImageResponse updateProfileImage(MultipartFile profileImageFile, String userLoginId) {
+		// TODO: 기존 이미지 파일 삭제 로직 추가 (S3 용량 관리)
+		String newProfileImageUrl = amazonS3Service.upload(profileImageFile, "profileImage");
+		userRepository.findByLoginId(userLoginId).updateProfileImage(newProfileImageUrl);
+
+		return new UpdateProfileImageResponse(newProfileImageUrl);
 	}
 }

--- a/be/src/main/java/kr/codesquad/user/service/UserService.java
+++ b/be/src/main/java/kr/codesquad/user/service/UserService.java
@@ -19,6 +19,7 @@ import kr.codesquad.user.dto.response.UpdateProfileImageResponse;
 import kr.codesquad.user.entity.User;
 import kr.codesquad.user.repository.UserRepository;
 import kr.codesquad.util.Constants;
+import kr.codesquad.util.S3ImageDirectory;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -43,7 +44,7 @@ public class UserService implements UserDetailsService {
 		if (profileImageFile == null) {
 			url = Constants.DEFAULT_PROFILE_IMAGE_URL;
 		} else {
-			url = amazonS3Service.upload(profileImageFile, "profileImage");
+			url = amazonS3Service.upload(profileImageFile, S3ImageDirectory.PROFILE_IMAGE);
 		}
 
 		String encodedPassword = bCryptPasswordEncoder.encode(userSignUpRequest.getPassword());
@@ -68,7 +69,7 @@ public class UserService implements UserDetailsService {
 		User user = userRepository.findByLoginId(userLoginId);
 		amazonS3Service.deleteImage(user.getProfileImageUrl()); // 기존 프로필 이미지 삭제
 
-		String newProfileImageUrl = amazonS3Service.upload(profileImageFile, "profileImage");
+		String newProfileImageUrl = amazonS3Service.upload(profileImageFile, S3ImageDirectory.PROFILE_IMAGE);
 		user.updateProfileImage(newProfileImageUrl);
 
 		return new UpdateProfileImageResponse(newProfileImageUrl);

--- a/be/src/main/java/kr/codesquad/util/S3ImageDirectory.java
+++ b/be/src/main/java/kr/codesquad/util/S3ImageDirectory.java
@@ -4,20 +4,22 @@ import java.util.Arrays;
 
 import kr.codesquad.core.error.CustomException;
 import kr.codesquad.core.error.statuscode.FileErrorCode;
-import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
-@AllArgsConstructor
+@Getter
+@RequiredArgsConstructor
 public enum S3ImageDirectory {
 	// root directory 에는 파일 저장 불가. 하위 directory 안에만 파일 저장 가능
 
 	PROFILE_IMAGE("profileImage"),
 	ITEM_IMAGE("itemImage");
 
-	private final String name;
+	private final String dirName;
 
 	public static String findDirectory(String fileUrl) {
 		return Arrays.stream(S3ImageDirectory.values())
-			.filter(dir -> fileUrl.contains(dir.name))
-			.findFirst().orElseThrow(() -> new CustomException(FileErrorCode.DIRECTROTY_NOT_FOUND)).name;
+			.filter(dir -> fileUrl.contains(dir.dirName))
+			.findFirst().orElseThrow(() -> new CustomException(FileErrorCode.DIRECTROTY_NOT_FOUND)).dirName;
 	}
 }

--- a/be/src/main/java/kr/codesquad/util/S3ImageDirectory.java
+++ b/be/src/main/java/kr/codesquad/util/S3ImageDirectory.java
@@ -17,7 +17,7 @@ public enum S3ImageDirectory {
 
 	public static String findDirectory(String fileUrl) {
 		return Arrays.stream(S3ImageDirectory.values())
-			.filter(dir -> fileUrl.contains(dir.name()))
-			.findFirst().orElseThrow(() -> new CustomException(FileErrorCode.DIRECTROTY_NOT_FOUND)).name();
+			.filter(dir -> fileUrl.contains(dir.name))
+			.findFirst().orElseThrow(() -> new CustomException(FileErrorCode.DIRECTROTY_NOT_FOUND)).name;
 	}
 }

--- a/be/src/main/java/kr/codesquad/util/S3ImageDirectory.java
+++ b/be/src/main/java/kr/codesquad/util/S3ImageDirectory.java
@@ -1,0 +1,23 @@
+package kr.codesquad.util;
+
+import java.util.Arrays;
+
+import kr.codesquad.core.error.CustomException;
+import kr.codesquad.core.error.statuscode.FileErrorCode;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum S3ImageDirectory {
+	// root directory 에는 파일 저장 불가. 하위 directory 안에만 파일 저장 가능
+
+	PROFILE_IMAGE("profileImage"),
+	ITEM_IMAGE("itemImage");
+
+	private final String name;
+
+	public static String findDirectory(String fileUrl) {
+		return Arrays.stream(S3ImageDirectory.values())
+			.filter(dir -> fileUrl.contains(dir.name()))
+			.findFirst().orElseThrow(() -> new CustomException(FileErrorCode.DIRECTROTY_NOT_FOUND)).name();
+	}
+}


### PR DESCRIPTION
## What is this PR? 👓
- https://github.com/max2023-4th-project-01/BE-B-Cokkiri-Market/issues/64

## Key changes 🔑
- S3에서 파일 삭제하는 로직을 작성했습니다.
- 기존에 등록한 프로필 이미지가 있다면 S3에서 삭제합니다.
    - 기본 이미지(=코끼리.png)  일 경우 삭제하지 않습니다.
- S3에 업로드 된 파일 이름이 한글이면 삭제되지 않는 버그가 있습니다. 

## To reviewers 👋
- 이 과정에서 S3 디렉토리 이름을 Enum을 사용하는 것으로 변경하게 되었습니다. 이에 따라 사용하는 코드가 달라집니다.

### 기존
```java
// 아이템 디렉토리에 저장 시
String url = amazonS3Service.upload(imageFile, "itemImage");

// 회원 프로필 디렉토리에 저장 시
String url = amazonS3Service.upload(imageFile, "profileImage");
```

### 변경
```java
// 아이템 디렉토리에 저장 시
String url = amazonS3Service.upload(imageFile, S3ImageDirectory.ITEM_IMAGE.dirName());

// 회원 프로필 디렉토리에 저장 시
String url = amazonS3Service.upload(imageFile, S3ImageDirectory.PROFILE_IMAGE.dirName());
```
