### PR TITLE
fix: ExceptionHandler 로그 레벨 변경

### DIFF
--- a/be/src/main/java/kr/codesquad/core/error/GlobalExceptionHandler.java
+++ b/be/src/main/java/kr/codesquad/core/error/GlobalExceptionHandler.java
@@ -25,7 +25,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	@ExceptionHandler(CustomException.class)
 	protected ResponseEntity<ErrorResponse> handleCustomException(CustomException ex) {
 		StatusCode statusCode = ex.getStatusCode();
-		log.warn("CustomException handling: {}", ex.toString());
+		log.info("CustomException handling: {}", ex.toString());
 		return ResponseEntity.status(statusCode.getHttpStatus()).body(ErrorResponse.builder()
 			.statusCode(statusCode.getHttpStatus())
 			.message(statusCode.getMessage()).build());
@@ -36,7 +36,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	protected ResponseEntity<Object> handleNoHandlerFoundException(NoHandlerFoundException ex, HttpHeaders headers,
 		HttpStatus status, WebRequest request) {
 		ErrorCode errorCode = ErrorCode.PAGE_NOT_FOUND;
-		log.warn("NoHandlerFoundException handling: {}", ex.toString());
+		log.info("NoHandlerFoundException handling: {}", ex.toString());
 		return ResponseEntity.status(errorCode.getHttpStatus())
 			.body(ErrorResponse.builder()
 				.statusCode(errorCode.getHttpStatus())
@@ -76,7 +76,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
 		HttpHeaders headers, HttpStatus status, WebRequest request) {
 		ErrorCode errorCode = ErrorCode.VALIDATION_FAILED;
-		log.warn("MethodArgumentNotValidException handling: {}", ex.getMessage());
+		log.info("MethodArgumentNotValidException handling: {}", ex.getMessage());
 		return ResponseEntity.status(errorCode.getHttpStatus())
 			.body(ErrorResponse.builder()
 				.statusCode(errorCode.getHttpStatus())


### PR DESCRIPTION
## What is this PR? 👓
- 

## Key changes 🔑
- 예측할 수 있는 에러는 log.info()로 변경.
- 나머지는 예측할 수 없는 에러이므로 log.warn() 그대로 유지.
- 외부 API에 대한 로그 레벨은 warn이어야 하지만, 예측할 수 없는 에러를 CustomException을 사용하여 예측할 수 있게 변경한 부분이 있기 때문에 log.info() 레벨을 사용. 
